### PR TITLE
Add date filter for usage stats

### DIFF
--- a/android/app/src/main/kotlin/com/example/hrishikesh/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/hrishikesh/MainActivity.kt
@@ -22,7 +22,13 @@ class MainActivity: FlutterActivity() {
                     result.success(androidId)
                 }
                 "getUsageStats" -> {
-                    val usageList = UsageStatsHelper.getUsageStats(this)
+                    val start = call.argument<Long>("start")
+                    val end = call.argument<Long>("end")
+                    val usageList = if (start != null && end != null) {
+                        UsageStatsHelper.getUsageStats(this, start, end)
+                    } else {
+                        UsageStatsHelper.getUsageStatsForToday(this)
+                    }
                     val mapped = usageList.map { usage ->
                         mapOf(
                             "packageName" to usage.packageName,
@@ -30,6 +36,10 @@ class MainActivity: FlutterActivity() {
                         )
                     }
                     result.success(mapped)
+                }
+                "hasUsagePermission" -> {
+                    val granted = UsageStatsHelper.hasUsagePermission(this)
+                    result.success(granted)
                 }
                 else -> result.notImplemented()
             }

--- a/android/app/src/main/kotlin/com/example/hrishikesh/UsageStatsHelper.kt
+++ b/android/app/src/main/kotlin/com/example/hrishikesh/UsageStatsHelper.kt
@@ -1,5 +1,6 @@
 package com.example.hrishikesh
 
+import android.app.AppOpsManager
 import android.app.usage.UsageStats
 import android.app.usage.UsageStatsManager
 import android.content.Context
@@ -15,14 +16,29 @@ data class AppUsageInfo(
 )
 
 object UsageStatsHelper {
-    fun getUsageStats(context: Context): List<AppUsageInfo> {
+    fun hasUsagePermission(context: Context): Boolean {
+        val appOps = context.getSystemService(Context.APP_OPS_SERVICE) as AppOpsManager
+        val mode = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            appOps.unsafeCheckOpNoThrow(
+                AppOpsManager.OPSTR_GET_USAGE_STATS,
+                android.os.Process.myUid(),
+                context.packageName
+            )
+        } else {
+            appOps.checkOpNoThrow(
+                AppOpsManager.OPSTR_GET_USAGE_STATS,
+                android.os.Process.myUid(),
+                context.packageName
+            )
+        }
+        return mode == AppOpsManager.MODE_ALLOWED
+    }
+
+    fun getUsageStats(context: Context, startTime: Long, endTime: Long): List<AppUsageInfo> {
         val usageStatsList = ArrayList<AppUsageInfo>()
 
         val usageStatsManager =
             context.getSystemService(Context.USAGE_STATS_SERVICE) as UsageStatsManager
-
-        val endTime = System.currentTimeMillis()
-        val startTime = endTime - 1000 * 60 * 60 // last 1 hour
 
         val stats: List<UsageStats> = usageStatsManager.queryUsageStats(
             UsageStatsManager.INTERVAL_DAILY,
@@ -46,5 +62,16 @@ object UsageStatsHelper {
         }
 
         return usageStatsList
+    }
+
+    fun getUsageStatsForToday(context: Context): List<AppUsageInfo> {
+        val calendar = Calendar.getInstance()
+        val endTime = calendar.timeInMillis
+        calendar.set(Calendar.HOUR_OF_DAY, 0)
+        calendar.set(Calendar.MINUTE, 0)
+        calendar.set(Calendar.SECOND, 0)
+        calendar.set(Calendar.MILLISECOND, 0)
+        val startTime = calendar.timeInMillis
+        return getUsageStats(context, startTime, endTime)
     }
 }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:android_intent_plus/android_intent.dart';
 import '../services/api_service.dart';
 import '../models/app_usage.dart';
 
@@ -10,15 +11,30 @@ class HomeScreen extends StatefulWidget {
   State<HomeScreen> createState() => _HomeScreenState();
 }
 
-class _HomeScreenState extends State<HomeScreen> {
+class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
   List<Map<String, dynamic>> _devices = [];
   bool _isLoading = true;
   List<AppUsage> _usage = [];
+  DateTime _selectedDate = DateTime.now();
 
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
     _initDeviceLogic();
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      _fetchUsageStats();
+    }
   }
 
   void _initDeviceLogic() async {
@@ -33,35 +49,82 @@ class _HomeScreenState extends State<HomeScreen> {
       currentDeviceId = null;
     }
 
-    List<AppUsage> usage = [];
-    try {
-      final List<dynamic>? result =
-          await channel.invokeMethod<List<dynamic>>('getUsageStats');
-      if (result != null) {
-        usage = result
-            .map((e) => AppUsage.fromMap(Map<dynamic, dynamic>.from(e)))
-            .toList();
-        usage.sort((a, b) => b.usage.compareTo(a.usage));
-      }
-    } on PlatformException {
-      usage = [];
-    }
-
     if (currentDeviceId != null) {
-      final filtered = allDevices
-          .where((d) => d['device_id'] == currentDeviceId)
-          .toList();
+      final filtered =
+          allDevices.where((d) => d['device_id'] == currentDeviceId).toList();
       setState(() {
         _devices = filtered;
-        _usage = usage;
-        _isLoading = false;
       });
     } else {
       setState(() {
         _devices = allDevices;
-        _usage = usage;
-        _isLoading = false;
       });
+    }
+
+    await _checkUsagePermission(openSettings: true);
+    await _fetchUsageStats();
+
+    setState(() => _isLoading = false);
+  }
+
+  Future<bool> _checkUsagePermission({bool openSettings = false}) async {
+    const MethodChannel channel = MethodChannel('parent_control/device');
+    final bool hasPermission =
+        await channel.invokeMethod<bool>('hasUsagePermission') ?? false;
+    if (!hasPermission && openSettings) {
+      const intent = AndroidIntent(
+        action: 'android.settings.USAGE_ACCESS_SETTINGS',
+      );
+      await intent.launch();
+    }
+    return hasPermission;
+  }
+
+  Future<void> _fetchUsageStats({DateTime? date}) async {
+    const MethodChannel channel = MethodChannel('parent_control/device');
+    final bool granted =
+        await channel.invokeMethod<bool>('hasUsagePermission') ?? false;
+    if (!granted) {
+      setState(() => _usage = []);
+      return;
+    }
+
+    try {
+      final target = date ?? _selectedDate;
+      final start = DateTime(target.year, target.month, target.day)
+          .millisecondsSinceEpoch;
+      final end = DateTime(target.year, target.month, target.day)
+          .add(const Duration(days: 1))
+          .millisecondsSinceEpoch;
+
+      final List<dynamic>? result = await channel.invokeMethod<List<dynamic>>(
+        'getUsageStats',
+        {'start': start, 'end': end},
+      );
+      if (result != null) {
+        final usage = result
+            .map((e) => AppUsage.fromMap(Map<dynamic, dynamic>.from(e)))
+            .toList();
+        usage.sort((a, b) => b.usage.compareTo(a.usage));
+        setState(() => _usage = usage);
+      } else {
+        setState(() => _usage = []);
+      }
+    } on PlatformException {
+      setState(() => _usage = []);
+    }
+  }
+
+  Future<void> _pickDate() async {
+    final DateTime? picked = await showDatePicker(
+      context: context,
+      initialDate: _selectedDate,
+      firstDate: DateTime.now().subtract(const Duration(days: 30)),
+      lastDate: DateTime.now(),
+    );
+    if (picked != null && picked != _selectedDate) {
+      setState(() => _selectedDate = picked);
+      await _fetchUsageStats(date: picked);
     }
   }
 
@@ -155,13 +218,24 @@ class _HomeScreenState extends State<HomeScreen> {
                         );
                       },
                     ),
-                  if (_usage.isNotEmpty) ...[
-                    const Padding(
-                      padding: EdgeInsets.symmetric(vertical: 8.0),
-                      child: Text('App Usage',
-                          style: TextStyle(
-                              fontSize: 18, fontWeight: FontWeight.bold)),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 8.0),
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Text(
+                          'App Usage (${_selectedDate.toString().split(' ')[0]})',
+                          style: const TextStyle(
+                              fontSize: 18, fontWeight: FontWeight.bold),
+                        ),
+                        IconButton(
+                          onPressed: _pickDate,
+                          icon: const Icon(Icons.calendar_today),
+                        ),
+                      ],
                     ),
+                  ),
+                  if (_usage.isNotEmpty)
                     ListView.builder(
                       shrinkWrap: true,
                       physics: const NeverScrollableScrollPhysics(),
@@ -177,8 +251,12 @@ class _HomeScreenState extends State<HomeScreen> {
                           trailing: Text(duration),
                         );
                       },
-                    ),
-                  ]
+                    )
+                  else
+                    const Padding(
+                      padding: EdgeInsets.symmetric(vertical: 8.0),
+                      child: Text('No usage data available.'),
+                    )
                 ],
               ),
             ),


### PR DESCRIPTION
## Summary
- extend method channel to accept start and end times
- allow date selection in home screen
- compute usage stats for chosen date

## Testing
- `flutter analyze` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6868f2e2f34c832d86a354516bd1387b