### PR TITLE
Fix installed apps not fully visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,10 @@ The home screen now features a **+** button that opens a new page
 displaying all user installed applications on the device. System
 packages are excluded automatically, while all other apps - including
 preinstalled Google applications - are listed. Applications without a
-launcher icon are shown using a default Android symbol. Apps are
+launcher icon are shown using a default Android symbol. On Android 11 and
+later the app requires the **QUERY_ALL_PACKAGES** permission to list all
+installed applications. This permission is declared in the Android
+manifest. Apps are
 grouped into the following categories:
 
 - Entertainment

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -8,6 +8,8 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.PACKAGE_USAGE_STATS"
         tools:ignore="ProtectedPermissions" />
+    <!-- Allows listing all installed apps on Android 11+ -->
+    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" /> <!-- ✅ REQUIRED -->
 
     <application


### PR DESCRIPTION
## Summary
- allow querying all apps by including QUERY_ALL_PACKAGES permission
- document the permission requirement in the readme

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68692969cb74832d8e86324c44de5f3d